### PR TITLE
prettyStream interface unification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,7 +131,9 @@ The behavior of the get accessor changes if `{ bunyan: true }` is passed
 to pinoms. In that case, it implements the
 [`bunyan.level`](https://github.com/trentm/node-bunyan#levels) function.
 
-### pinoms.prettyStream({ [prettifier], [dest] })
+### pinoms.prettyStream({ [opts],  [prettifier], [dest] })
+
+_Note_: after 4.1.0, the list of parameters was changed, now it is the same as that of `pino` `prettyStream`.
 
 Manually create an output stream with a prettifier applied.
 

--- a/index.js
+++ b/index.js
@@ -87,8 +87,8 @@ function pinoMultiStream (opts, stream) {
 Object.assign(pinoMultiStream, pino)
 pinoMultiStream.multistream = multistream
 pinoMultiStream.prettyStream = (args = {}) => {
-  const { prettifier, dest = process.stdout } = args
-  return getPrettyStream({}, prettifier, dest)
+  const { opts = {}, prettifier, dest = process.stdout } = args
+  return getPrettyStream(opts, prettifier, dest)
 }
 
 module.exports = pinoMultiStream


### PR DESCRIPTION
This PR makes method `prettyStream` of `pino-multi-stream` consistent with `prettyStream` function of `pino` (see https://github.com/pinojs/pino/blob/master/lib/tools.js#L154).
Now it takes `opts` parameter in the same way as the function from `pino` does.

Example: 
```javascript
const pinoms = require('pino-multi-stream');

const prettyStream = pinoms.prettyStream(
    { colorize: true, translateTime: "SYS:standard", ignore: "hostname,pid,time" }
);

```
Related issue: #27.